### PR TITLE
Fix: indicator position

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -2,7 +2,8 @@
   display: none;
   position: sticky;
   position: -webkit-sticky;
-  right: 1em;
+  margin-right: 1em;
+  margin-left: auto;
   bottom: 1em;
   text-align: center;
   width: #{$offline_indicator_width};
@@ -24,8 +25,6 @@
   }
   .mobile-view & {
     width: calc(100% - 20px);
-    right: unset;
-    bottom: 1em;
     margin: auto;
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,16 +1,19 @@
 .offline-indicator {
   display: none;
-  position: fixed;
+  position: sticky;
+  position: -webkit-sticky;
   right: 1em;
   bottom: 1em;
   text-align: center;
   width: #{$offline_indicator_width};
-  padding: 1em;
   border-radius: #{$offline_indicator_rounding};
   background-color: #{$offline_indicator_background_color};
   color: #{$offline_indicator_text_color};
   border: 1px solid #{$offline_indicator_border_color};
   z-index: z("header") - 10;
+  .offline-content {
+    padding: 1em;
+  }
   span:first-child {
     font-weight: 600;
     display: block;
@@ -20,7 +23,9 @@
     display: block;
   }
   .mobile-view & {
-    width: calc(100vw - 4em);
+    width: calc(100% - 20px);
+    right: unset;
     bottom: 1em;
+    margin: auto;
   }
 }

--- a/javascripts/discourse/templates/connectors/above-footer/offline-indicator.hbs
+++ b/javascripts/discourse/templates/connectors/above-footer/offline-indicator.hbs
@@ -1,4 +1,4 @@
-<div class="wrap">
+<div class="offline-content">
   <span>{{d-icon (theme-setting 'offline_indicator_icon')}} {{i18n (theme-prefix "offline.title")}}</span>
   <span>{{i18n (theme-prefix "offline.description")}}</span>
 </div>


### PR DESCRIPTION
Use `position: sticky` instead `position: fixed`.
Change the width on mobile to fit more Discourse.
Rename `.wrap` class to `.offline-content`.
Remove padding from `.offline-indicator` class and add it to `.offline-content` class.