### PR TITLE
FIX: Convert hbs connector template to gjs

### DIFF
--- a/javascripts/discourse/api-initializers/offline-init.js
+++ b/javascripts/discourse/api-initializers/offline-init.js
@@ -1,15 +1,13 @@
-export default {
-  name: "offline-indicator",
-  initialize() {
-    window.addEventListener('online',  updateOnlineStatus);
-    window.addEventListener('offline',  updateOnlineStatus);
+import { apiInitializer } from "discourse/lib/api";
 
-    function updateOnlineStatus(event) {
-      if (!navigator.onLine) {
-        document.body.classList.add("offline");
-      } else {
-        document.body.classList.remove("offline");
-      }
-    }
-  },
-};
+export default apiInitializer(() => {
+  const updateOnlineStatus = () => {
+    document.body.classList.toggle("offline", !navigator.onLine);
+  };
+
+  // set the initial state in case the app boots while already offline
+  updateOnlineStatus();
+
+  window.addEventListener("online", updateOnlineStatus);
+  window.addEventListener("offline", updateOnlineStatus);
+});

--- a/javascripts/discourse/connectors/above-footer/offline-indicator.gjs
+++ b/javascripts/discourse/connectors/above-footer/offline-indicator.gjs
@@ -1,0 +1,14 @@
+import dIcon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+export default <template>
+  <div class="above-footer-outlet offline-indicator">
+    <div class="offline-content">
+      <span>
+        {{dIcon settings.offline_indicator_icon}}
+        {{i18n (themePrefix "offline.title")}}
+      </span>
+      <span>{{i18n (themePrefix "offline.description")}}</span>
+    </div>
+  </div>
+</template>;

--- a/javascripts/discourse/templates/connectors/above-footer/offline-indicator.hbs
+++ b/javascripts/discourse/templates/connectors/above-footer/offline-indicator.hbs
@@ -1,4 +1,0 @@
-<div class="offline-content">
-  <span>{{d-icon (theme-setting 'offline_indicator_icon')}} {{i18n (theme-prefix "offline.title")}}</span>
-  <span>{{i18n (theme-prefix "offline.description")}}</span>
-</div>


### PR DESCRIPTION
Discourse's theme compiler now flags every `.hbs` file in a theme with the `discourse.hbs-extension` deprecation (https://meta.discourse.org/t/398896), so site admins running this component see an admin notice saying the theme contains code which needs updating.

This converts the `above-footer` connector template to a modern `.gjs` connector component:

- Glimmer connectors aren't auto-wrapped the way classic hbs connectors were, so the wrapper div (with the same `above-footer-outlet offline-indicator` classes core used to add) is now part of the template — the existing CSS in `common.scss` keeps working unchanged.
- The initializer is modernized to the `apiInitializer` format, and now applies the online/offline state once at boot. Previously the `offline` body class was only toggled on connectivity *changes*, so a page loaded while already offline never showed the indicator.

Tested: passes the standard Discourse theme ESLint config, and deployed on a production Discourse site — the admin notice clears and the indicator still appears/disappears correctly when connectivity drops and returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)